### PR TITLE
Allow to change journal socket

### DIFF
--- a/journal_writer.go
+++ b/journal_writer.go
@@ -9,6 +9,12 @@ import (
 	"syscall"
 )
 
+// socket to journald
+// for testing purposes only - the socket path can be changed at runtime
+// if it will be set (e.g. to "/tmp/journal.socket") the writer will send the message on that socket
+// and not on the default one ("/run/systemd/journal/socket")
+var TESTING_SOCKET_PATH = ""
+
 // journalWriter encapsulates the behaviour of writing unixgrams to the journal socket.
 // It will try to write the message with a single write call, but if the message is too large
 // it will write the message to a temporary file and send the file descriptor as OOB data.
@@ -44,8 +50,14 @@ func newJournalWriter() (io.Writer, error) {
 		return nil, err
 	}
 
+	socketName := "/run/systemd/journal/socket"
+	// we respect TESTING_SOCKET_PATH - for testing purposes only
+	if TESTING_SOCKET_PATH != "" {
+		socketName = TESTING_SOCKET_PATH
+	}
+
 	addr := &net.UnixAddr{
-		Name: "/run/systemd/journal/socket",
+		Name: socketName,
 		Net:  "unixgram",
 	}
 


### PR DESCRIPTION
As mentioned in #22 it would be great to change the journal socket to connect to at runtime.

I am using that during cross-development (not working on Linux, macOS/Windows instead).

I did also write a journald mock, listening on a socket like /tmp/journal.socket, getting data, preserve them on a list of log messages. So test cases can retrieve the list and compare the log messages with expected ones.

This journald mock is not included in this tiny PR. If there is interest, I can also add it here and add a small test case to demo how to use that for testimg.
